### PR TITLE
feat: Add MapperColor enum with preset colors and ability to add custom colors to configurable ron files.

### DIFF
--- a/src/graphics/live/mapper_view.rs
+++ b/src/graphics/live/mapper_view.rs
@@ -7,75 +7,85 @@ use crate::logs::location::{Location, LocationType};
 
 use super::mapper::LookUpColor;
 
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum MapperColor {
+    Blue,
+    Green,
+    Yellow,
+    Red,
+    RGB(u8, u8, u8),
+}
 
+impl From<&MapperColor> for Color32 {
+    fn from(value: &MapperColor) -> Self {
+        match value {
+            MapperColor::Blue => Color32::from_rgb(30, 155, 255),
+            MapperColor::Green => Color32::from_rgb(45, 255, 30),
+            MapperColor::Yellow => Color32::from_rgb(255, 255, 30),
+            MapperColor::Red => Color32::from_rgb(255, 15, 15),
+            MapperColor::RGB(r, g, b) => Color32::from_rgb(*r, *g, *b),
+        }
+    }
+}
 
 #[derive(Default, Serialize, Deserialize, Debug)]
 pub struct LevelView {
-  
-  key_colors: Vec<HashMap<u64, HashMap<[u8; 3], Vec<u64>>>>,
-  objective_colors: HashMap<String, HashMap<u64, HashMap<[u8; 3], Vec<u64>>>>,
-  ignore_zones: Vec<u64>,
-
+    key_colors: Vec<HashMap<u64, HashMap<MapperColor, Vec<u64>>>>,
+    objective_colors: HashMap<String, HashMap<u64, HashMap<MapperColor, Vec<u64>>>>,
+    ignore_zones: Vec<u64>,
 }
 
 impl LookUpColor for LevelView {
-  fn lookup(&self, location_vec_id: usize, location: &Location) -> Option<Color32> {
+    fn lookup(&self, location_vec_id: usize, location: &Location) -> Option<Color32> {
+        let zone = location.get_zone()?;
+        let id = location.get_id()?;
 
-    let zone = location.get_zone()?;
-    let id = location.get_id()?;
+        match location.get_type() {
+            LocationType::Unknown => None,
+            LocationType::ColoredKey | LocationType::BulkheadKey => {
+                if location_vec_id >= self.key_colors.len() {
+                    return None;
+                }
 
-    match location.get_type() {
-      LocationType::Unknown => None,
-      LocationType::ColoredKey | LocationType::BulkheadKey => {
-        if location_vec_id >= self.key_colors.len() { return None }
+                let map = &self.key_colors[location_vec_id];
+                let zone_colors = map.get(&zone)?;
 
-        let map = &self.key_colors[location_vec_id];
-        let zone_colors = map.get(&zone)?;
-        
-        for (color, vec) in zone_colors {
-          if vec.contains(&id) {
-            return Some(Color32::from_rgb(
-              color[0], 
-              color[1],
-              color[2] 
-            ))
-          }
+                for (color, vec) in zone_colors {
+                    if vec.contains(&id) {
+                        return Some(color.into());
+                    }
+                }
+
+                None
+            }
+            LocationType::Objective => {
+                let name = location.get_name()?;
+
+                let map = self.objective_colors.get(name)?;
+                let zone_colors = map.get(&zone)?;
+
+                for (color, vec) in zone_colors {
+                    if vec.contains(&id) {
+                        return Some(color.into());
+                    }
+                }
+
+                None
+            }
         }
-
-        None
-      },
-      LocationType::Objective => {
-        let name = location.get_name()?;
-
-        let map = self.objective_colors.get(name)?;
-        let zone_colors = map.get(&zone)?;
-
-        for (color, vec) in zone_colors {
-          if vec.contains(&id) {
-            return Some(Color32::from_rgb(
-              color[0], 
-              color[1],
-              color[2] 
-            ))
-          }
-        }
-
-        None
-      },
     }
-  }
-  
-  fn is_valid_zone(&self, zone: &u64) -> bool {
-    !self.ignore_zones.contains(zone)  
-  }
+
+    fn is_valid_zone(&self, zone: &u64) -> bool {
+        !self.ignore_zones.contains(zone)
+    }
 }
 
 impl LookUpColor for Option<&LevelView> {
-  fn lookup(&self, location_vec_id: usize, location: &Location) -> Option<Color32> {
-    self.map(|s| s.lookup(location_vec_id, location)).flatten()    
-  }
+    fn lookup(&self, location_vec_id: usize, location: &Location) -> Option<Color32> {
+        self.map(|s| s.lookup(location_vec_id, location)).flatten()
+    }
 
-  fn is_valid_zone(&self, zone: &u64) -> bool {
-    self.map(|s| s.is_valid_zone(zone)).unwrap_or(true)
-  }
+    fn is_valid_zone(&self, zone: &u64) -> bool {
+        self.map(|s| s.is_valid_zone(zone)).unwrap_or(true)
+    }
 }


### PR DESCRIPTION
Added new `enum MapperColor` that has preset values for `Blue`, `Green`, `Yellow` and `Red` as well as for custom rgb value with `RGB(R, G, B)`

Usage:
For RON files of levels you can use the enum values as a key to color the ri/seeds/collectibles a specific way.
```rust
LevelView(
  key_colors: [
    // Key for Zone 52
    {
      50: {
        Blue: [0, 1, 2, 3], // light blue aka god keys
        Green: [4, 5, 6, 7, 14, 16, 18], // green aka good keys
        Yellow: [8, 9, 10, 12, 13, 15, 17, 19, 21, 40, 41, 42, 43, 44, 47, 51], // yellow aka mediocre but still runnable
        Red: [11, 20, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 45, 46, 48, 49, 50, 52, 53, 54, 55, 56, 57] // red completely horrible keys
      }
    },
  ],
  objective_colors: {
	// Zone 52 HSU (marked in logs as enum ZONE_3)
    "HSU": {
      3: {
        Blue: [15], // god hsu           : light blue
        Green: [16], // still very good hsu   : green
        Yellow: [17], // mediocre hsu        : yellow
        RGB(255, 0, 0): [18], // very bad hsu          : red
      }
    },
  },
  ignore_zones: [ 51, ]
)
```